### PR TITLE
Add onlyContains method to iUtils InventoryUtils

### DIFF
--- a/iutils/src/main/java/net/runelite/client/plugins/iutils/InventoryUtils.java
+++ b/iutils/src/main/java/net/runelite/client/plugins/iutils/InventoryUtils.java
@@ -345,6 +345,22 @@ public class InventoryUtils {
         }
         return false;
     }
+    
+    public boolean onlyContains(Collection<Integer> itemIds) {
+        if (client.getItemContainer(InventoryID.INVENTORY) == null) {
+            return false;
+        }
+
+        Collection<WidgetItem> inventoryItems = getAllItems();
+        
+        for (WidgetItem item : inventoryItems) {
+            if (!itemIds.contains(item.getId())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     public void dropItem(WidgetItem item) {
         assert !client.isClientThread();


### PR DESCRIPTION
These changes add an `onlyContains` method to iUtils' InventoryUtils. 

This method performs a check to see if the inventory _only_ contains the items supplied. If the inventory contains only the supplied item IDs, it will return true. Otherwise, this method will return false.

**Example:**
Inventory contains only the following three item IDs: `670, 675, 676`.
`.onlyContains(Arrays.asList(670, 675, 676))` => `true`
`.onlyContains(Arrays.asList(100, 675, 676))` => `false`

Inventory contains only the following four item IDs: `100, 670, 675, 676`.
`.onlyContains(Arrays.asList(100, 670, 675, 676))` => `true`
`.onlyContains(Arrays.asList(670, 675, 676))` => `false`
`.onlyContains(Arrays.asList(100, 675, 676))` => `false`